### PR TITLE
issue #339 (Replace package.json in .mdw folder with package.yaml)

### DIFF
--- a/mdw-common/src/com/centurylink/mdw/config/YamlBuilder.java
+++ b/mdw-common/src/com/centurylink/mdw/config/YamlBuilder.java
@@ -17,6 +17,7 @@ package com.centurylink.mdw.config;
 
 import java.util.Map;
 
+import org.json.JSONObject;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.representer.Representer;
@@ -34,6 +35,12 @@ public class YamlBuilder {
     public YamlBuilder(Map<?,?> map) {
         this();
         append(map);
+    }
+
+    public YamlBuilder(JSONObject json) {
+        this();
+        Yaml yaml= new Yaml();
+        append((Map<?,?>)yaml.load(json.toString()));
     }
 
     public YamlBuilder append(Map<?,?> map) {

--- a/mdw-common/src/com/centurylink/mdw/dataaccess/file/LoaderPersisterVcs.java
+++ b/mdw-common/src/com/centurylink/mdw/dataaccess/file/LoaderPersisterVcs.java
@@ -38,9 +38,11 @@ import java.util.regex.Pattern;
 import org.apache.xmlbeans.XmlException;
 import org.apache.xmlbeans.XmlOptions;
 import org.json.JSONException;
+import org.yaml.snakeyaml.Yaml;
 
 import com.centurylink.mdw.activity.types.TaskActivity;
 import com.centurylink.mdw.cache.impl.AssetRefCache;
+import com.centurylink.mdw.config.YamlBuilder;
 import com.centurylink.mdw.constant.OwnerType;
 import com.centurylink.mdw.constant.WorkAttributeConstant;
 import com.centurylink.mdw.dataaccess.AssetRef;
@@ -383,10 +385,20 @@ public class LoaderPersisterVcs implements ProcessLoader, ProcessPersister {
         packageVO.setSchemaVersion(DataAccess.currentSchemaVersion);
 
         String pkgJson = new String(read(pkgDir.getMetaFile()));
-        Package jsonPkg = new Package(new JsonObject(pkgJson));
-        packageVO.setGroup(jsonPkg.getGroup());
-        packageVO.setAttributes(jsonPkg.getAttributes());
-        packageVO.setMetaContent(pkgJson);
+        if (pkgDir.isYaml()) {
+            Yaml yaml= new Yaml();
+            Map<String,Object> map= (Map<String, Object>) yaml.load(pkgJson);
+            Package jsonPkg = new Package(map);
+            packageVO.setGroup(jsonPkg.getGroup());
+            packageVO.setAttributes(jsonPkg.getAttributes());
+            packageVO.setMetaContent(pkgJson);
+        }
+        else {
+            Package jsonPkg = new Package(new JsonObject(pkgJson));
+            packageVO.setGroup(jsonPkg.getGroup());
+            packageVO.setAttributes(jsonPkg.getAttributes());
+            packageVO.setMetaContent(pkgJson);
+        }
 
         packageVO.setProcesses(loadProcesses(pkgDir, deep));
         packageVO.setAssets(loadAssets(pkgDir, deep));
@@ -406,7 +418,8 @@ public class LoaderPersisterVcs implements ProcessLoader, ProcessPersister {
                 throw new IOException("Unable to create metadata directory under: " + pkgDir);
         }
 
-        String pkgContent = packageVO.getJson(false).toString(2);
+        String pkgContent = new YamlBuilder(packageVO.getJson(false)).toString();
+
         write(pkgContent.getBytes(), pkgDir.getMetaFile());
 
         packageVO.setId(versionControl.getId(pkgDir.getLogicalDir()));
@@ -1180,6 +1193,7 @@ public class LoaderPersisterVcs implements ProcessLoader, ProcessPersister {
             else {
                 pkgDir = getTopLevelPackageDir(packageVO.getName());
             }
+            pkgDir.setYaml(true);
             Long id = save(packageVO, pkgDir, persistType == PersistType.IMPORT || persistType == PersistType.IMPORT_JSON);
             pkgDir.parse();  // sync
             return id;

--- a/mdw-common/src/com/centurylink/mdw/dataaccess/file/LoaderPersisterVcs.java
+++ b/mdw-common/src/com/centurylink/mdw/dataaccess/file/LoaderPersisterVcs.java
@@ -375,6 +375,7 @@ public class LoaderPersisterVcs implements ProcessLoader, ProcessPersister {
 
     // FileSystemAccess methods
 
+    @SuppressWarnings("unchecked")
     public Package loadPackage(PackageDir pkgDir, boolean deep) throws IOException, XmlException, JSONException, DataAccessException {
         Package packageVO = new Package();
 

--- a/mdw-common/src/com/centurylink/mdw/dataaccess/file/PackageDir.java
+++ b/mdw-common/src/com/centurylink/mdw/dataaccess/file/PackageDir.java
@@ -19,9 +19,13 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.yaml.snakeyaml.Yaml;
 
 import com.centurylink.mdw.dataaccess.AssetRevision;
 import com.centurylink.mdw.dataaccess.DataAccessException;
@@ -39,6 +43,7 @@ public class PackageDir extends File {
 
     public static final String META_DIR = ".mdw";
     public static final String PACKAGE_JSON_PATH = META_DIR + "/package.json";
+    public static final String PACKAGE_YAML_PATH = META_DIR + "/package.yaml";
     public static final String VERSIONS_PATH = META_DIR + "/versions";
     public static final String ARCHIVE_SUBDIR = "Archive";
 
@@ -74,30 +79,53 @@ public class PackageDir extends File {
     private long pkgId;
     public long getId() { return pkgId; }
 
+    private Boolean yaml;
+    public boolean isYaml() { return yaml == null ? false : yaml; }
+    public void setYaml(boolean yaml) { this.yaml = yaml; }
+
     private File metaFile;
     public File getMetaFile() {
-        metaFile = new File(toString() + "/" + PACKAGE_JSON_PATH);
+        metaFile = new File(toString() + "/" + PACKAGE_YAML_PATH);
+        if (!isYaml() && !metaFile.exists())
+            metaFile = new File(toString() + "/" + PACKAGE_JSON_PATH);
         return metaFile;
     }
 
     public void parse() throws DataAccessException {
+        yaml = new File(toString() + "/" + PACKAGE_YAML_PATH).exists();
+        parse(yaml);
+    }
+
+    public void parse(boolean yaml) throws DataAccessException {
         try {
+            this.yaml = yaml;
             File pkgFile = getMetaFile();
             if (!pkgFile.exists())
                 throw new FileNotFoundException(pkgFile.getAbsolutePath());
-            FileInputStream fis = null;
-            try {
-                fis = new FileInputStream(pkgFile);
-                byte[] bytes = new byte[(int) pkgFile.length()];
-                fis.read(bytes);
-                Package pkgVo = new Package(new JsonObject(new String(bytes)));
-                pkgName = pkgVo.getName();
-                pkgVersion = pkgVo.getVersionString();
-                schemaVersion = Asset.formatVersion(pkgVo.getSchemaVersion());
+            if (yaml) {
+                Yaml yamlLoader = new Yaml();
+                Map map = (Map) yamlLoader
+                        .load(new String(Files.readAllBytes(Paths.get(pkgFile.getPath()))));
+                pkgName = (String) map.get("name");
+                pkgVersion = (String) map.get("version");
+                schemaVersion = (String) map.get("schemaVersion");
             }
-            finally {
-                if (fis != null)
-                    fis.close();;
+            else {
+                FileInputStream fis = null;
+                try {
+                    fis = new FileInputStream(pkgFile);
+                    byte[] bytes = new byte[(int) pkgFile.length()];
+                    fis.read(bytes);
+                    Package pkgVo = new Package(new JsonObject(new String(bytes)));
+                    pkgName = pkgVo.getName();
+                    pkgVersion = pkgVo.getVersionString();
+                    schemaVersion = Asset.formatVersion(pkgVo.getSchemaVersion());
+                }
+                finally {
+                    if (fis != null)
+                        fis.close();
+                    ;
+                }
             }
             String archivePath = new File(storageDir.toString() + "/Archive/").toString();
             if (toString().startsWith(archivePath)) {

--- a/mdw-common/src/com/centurylink/mdw/dataaccess/file/PackageDir.java
+++ b/mdw-common/src/com/centurylink/mdw/dataaccess/file/PackageDir.java
@@ -96,6 +96,7 @@ public class PackageDir extends File {
         parse(yaml);
     }
 
+    @SuppressWarnings("rawtypes")
     public void parse(boolean yaml) throws DataAccessException {
         try {
             this.yaml = yaml;

--- a/mdw-common/src/com/centurylink/mdw/model/workflow/Package.java
+++ b/mdw-common/src/com/centurylink/mdw/model/workflow/Package.java
@@ -44,8 +44,6 @@ import com.centurylink.mdw.model.task.TaskTemplate;
 import com.centurylink.mdw.model.variable.Variable;
 import com.centurylink.mdw.spring.SpringAppContext;
 import com.centurylink.mdw.util.JsonUtil;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 public class Package implements Serializable, Jsonable {
 
@@ -118,12 +116,12 @@ public class Package implements Serializable, Jsonable {
     public Map<String,List<Attribute>> getAttributesByGroup() {
         if (attributes == null)
             return null;
-        Map<String,List<Attribute>> grouped = new HashMap<String,List<Attribute>>();
+        Map<String,List<Attribute>> grouped = new HashMap<>();
         for (Attribute attribute : attributes) {
             String group = attribute.getAttributeGroup();
             List<Attribute> groupAttrs = grouped.get(group);
             if (groupAttrs == null) {
-                groupAttrs = new ArrayList<Attribute>();
+                groupAttrs = new ArrayList<>();
                 grouped.put(group, groupAttrs);
             }
             groupAttrs.add(attribute);
@@ -377,10 +375,10 @@ public class Package implements Serializable, Jsonable {
         this.metaContent = metaContent;
     }
 
+    @SuppressWarnings("unchecked")
     public List<Attribute> getMetaAttributes() throws XmlException {
         if (metaContent == null || metaContent.isEmpty())
             return null;
-        List<Attribute> metaAttributes = new ArrayList<>();
         if (metaContent.trim().startsWith("{")) {
             Package metaPkg = new Package(new JsonObject(metaContent));
             return metaPkg.getAttributes();
@@ -421,7 +419,7 @@ public class Package implements Serializable, Jsonable {
     }
 
     public void hashProperties() {
-        properties = new HashMap<String,String>();
+        properties = new HashMap<>();
         if (attributes!=null) {
             for (Attribute attr: attributes) {
                 properties.put(attr.getAttributeName(), attr.getAttributeValue());
@@ -549,6 +547,7 @@ public class Package implements Serializable, Jsonable {
         return getLabel();
     }
 
+    @SuppressWarnings("unchecked")
     public Package(Map<?, ?> map) {
         if (map.get("name") != null)
             this.setName((String)map.get("name"));

--- a/mdw-hub/src/com/centurylink/mdw/hub/servlet/AssetContentServlet.java
+++ b/mdw-hub/src/com/centurylink/mdw/hub/servlet/AssetContentServlet.java
@@ -232,6 +232,7 @@ public class AssetContentServlet extends HttpServlet {
                             if (pkgDir == null) {
                                 // new pkg
                                 pkgDir = new PackageDir(persisterVcs.getStorageDir(), pkg, persisterVcs.getVersionControl());
+                                pkgDir.setYaml(true);
                             }
                             persisterVcs.save(pkg, pkgDir, true);
                             pkgDir.parse(); // sync

--- a/mdw-services/src/com/centurylink/mdw/services/asset/AssetServicesImpl.java
+++ b/mdw-services/src/com/centurylink/mdw/services/asset/AssetServicesImpl.java
@@ -36,6 +36,7 @@ import com.centurylink.mdw.bpm.PackageDocument;
 import com.centurylink.mdw.common.service.Query;
 import com.centurylink.mdw.common.service.ServiceException;
 import com.centurylink.mdw.config.PropertyManager;
+import com.centurylink.mdw.config.YamlBuilder;
 import com.centurylink.mdw.constant.PropertyNames;
 import com.centurylink.mdw.dataaccess.AssetRevision;
 import com.centurylink.mdw.dataaccess.DataAccess;
@@ -304,7 +305,7 @@ public class AssetServicesImpl implements AssetServices {
         try {
             JSONObject json = pkg.getJson();
             json.put("name", packageName);
-            FileHelper.writeToFile(new ByteArrayInputStream(json.toString(2).getBytes()), new File(metaDir + "/package.json"));
+            FileHelper.writeToFile(new ByteArrayInputStream(new YamlBuilder(json).toString().getBytes()), new File(metaDir + "/package.yaml"));
         }
         catch (Exception ex) {
             throw new ServiceException(ServiceException.INTERNAL_ERROR, ex.getMessage());

--- a/mdw-workflow/assets/com/centurylink/mdw/base/.mdw/package.json
+++ b/mdw-workflow/assets/com/centurylink/mdw/base/.mdw/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "com.centurylink.mdw.base",
-  "schemaVersion": "6.0",
-  "version": "6.0.13"
-}

--- a/mdw-workflow/assets/com/centurylink/mdw/base/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/base/.mdw/package.yaml
@@ -1,3 +1,3 @@
 schemaVersion: '6.1'
 name: com.centurylink.mdw.base
-version: 6.0.13
+version: 6.1.01

--- a/mdw-workflow/assets/com/centurylink/mdw/base/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/base/.mdw/package.yaml
@@ -1,3 +1,3 @@
-schemaVersion: '6.0'
+schemaVersion: '6.1'
 name: com.centurylink.mdw.base
 version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/base/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/base/.mdw/package.yaml
@@ -1,0 +1,3 @@
+schemaVersion: '6.0'
+name: com.centurylink.mdw.base
+version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/camel/.mdw/package.json
+++ b/mdw-workflow/assets/com/centurylink/mdw/camel/.mdw/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "com.centurylink.mdw.camel",
-  "schemaVersion": "6.0",
-  "version": "6.0.13"
-}

--- a/mdw-workflow/assets/com/centurylink/mdw/camel/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/camel/.mdw/package.yaml
@@ -1,0 +1,3 @@
+schemaVersion: '6.0'
+name: com.centurylink.mdw.camel
+version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/camel/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/camel/.mdw/package.yaml
@@ -1,3 +1,3 @@
-schemaVersion: '6.0'
+schemaVersion: '6.1'
 name: com.centurylink.mdw.camel
 version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/camel/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/camel/.mdw/package.yaml
@@ -1,3 +1,3 @@
 schemaVersion: '6.1'
 name: com.centurylink.mdw.camel
-version: 6.0.13
+version: 6.1.01

--- a/mdw-workflow/assets/com/centurylink/mdw/db/.mdw/package.json
+++ b/mdw-workflow/assets/com/centurylink/mdw/db/.mdw/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "com.centurylink.mdw.db",
-  "schemaVersion": "6.0",
-  "version": "6.0.13"
-}

--- a/mdw-workflow/assets/com/centurylink/mdw/db/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/db/.mdw/package.yaml
@@ -1,3 +1,3 @@
 schemaVersion: '6.1'
 name: com.centurylink.mdw.db
-version: 6.0.13
+version: 6.1.01

--- a/mdw-workflow/assets/com/centurylink/mdw/db/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/db/.mdw/package.yaml
@@ -1,3 +1,3 @@
-schemaVersion: '6.0'
+schemaVersion: '6.1'
 name: com.centurylink.mdw.db
 version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/db/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/db/.mdw/package.yaml
@@ -1,0 +1,3 @@
+schemaVersion: '6.0'
+name: com.centurylink.mdw.db
+version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/drools/.mdw/package.json
+++ b/mdw-workflow/assets/com/centurylink/mdw/drools/.mdw/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "com.centurylink.mdw.drools",
-  "schemaVersion": "6.0",
-  "version": "6.0.13"
-}

--- a/mdw-workflow/assets/com/centurylink/mdw/drools/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/drools/.mdw/package.yaml
@@ -1,3 +1,3 @@
-schemaVersion: '6.0'
+schemaVersion: '6.1'
 name: com.centurylink.mdw.drools
 version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/drools/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/drools/.mdw/package.yaml
@@ -1,0 +1,3 @@
+schemaVersion: '6.0'
+name: com.centurylink.mdw.drools
+version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/drools/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/drools/.mdw/package.yaml
@@ -1,3 +1,3 @@
 schemaVersion: '6.1'
 name: com.centurylink.mdw.drools
-version: 6.0.13
+version: 6.1.01

--- a/mdw-workflow/assets/com/centurylink/mdw/kafka/.mdw/package.json
+++ b/mdw-workflow/assets/com/centurylink/mdw/kafka/.mdw/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "com.centurylink.mdw.kafka",
-  "schemaVersion": "6.0",
-  "version": "6.0.13"
-}

--- a/mdw-workflow/assets/com/centurylink/mdw/kafka/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/kafka/.mdw/package.yaml
@@ -1,3 +1,3 @@
-schemaVersion: '6.0'
+schemaVersion: '6.1'
 name: com.centurylink.mdw.kafka
 version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/kafka/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/kafka/.mdw/package.yaml
@@ -1,3 +1,3 @@
 schemaVersion: '6.1'
 name: com.centurylink.mdw.kafka
-version: 6.0.13
+version: 6.1.01

--- a/mdw-workflow/assets/com/centurylink/mdw/kafka/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/kafka/.mdw/package.yaml
@@ -1,0 +1,3 @@
+schemaVersion: '6.0'
+name: com.centurylink.mdw.kafka
+version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/microservice/.mdw/package.json
+++ b/mdw-workflow/assets/com/centurylink/mdw/microservice/.mdw/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "com.centurylink.mdw.microservice",
-  "schemaVersion": "6.0",
-  "version": "6.0.13"
-}

--- a/mdw-workflow/assets/com/centurylink/mdw/microservice/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/microservice/.mdw/package.yaml
@@ -1,0 +1,3 @@
+schemaVersion: '6.0'
+name: com.centurylink.mdw.microservice
+version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/microservice/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/microservice/.mdw/package.yaml
@@ -1,3 +1,3 @@
 schemaVersion: '6.1'
 name: com.centurylink.mdw.microservice
-version: 6.0.13
+version: 6.1.01

--- a/mdw-workflow/assets/com/centurylink/mdw/microservice/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/microservice/.mdw/package.yaml
@@ -1,3 +1,3 @@
-schemaVersion: '6.0'
+schemaVersion: '6.1'
 name: com.centurylink.mdw.microservice
 version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/mysql/.mdw/package.json
+++ b/mdw-workflow/assets/com/centurylink/mdw/mysql/.mdw/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "com.centurylink.mdw.mysql",
-  "schemaVersion": "6.0",
-  "version": "6.0.13"
-}

--- a/mdw-workflow/assets/com/centurylink/mdw/mysql/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/mysql/.mdw/package.yaml
@@ -1,3 +1,3 @@
-schemaVersion: '6.0'
+schemaVersion: '6.1'
 name: com.centurylink.mdw.mysql
 version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/mysql/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/mysql/.mdw/package.yaml
@@ -1,3 +1,3 @@
 schemaVersion: '6.1'
 name: com.centurylink.mdw.mysql
-version: 6.0.13
+version: 6.1.01

--- a/mdw-workflow/assets/com/centurylink/mdw/mysql/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/mysql/.mdw/package.yaml
@@ -1,0 +1,3 @@
+schemaVersion: '6.0'
+name: com.centurylink.mdw.mysql
+version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/node/.mdw/package.json
+++ b/mdw-workflow/assets/com/centurylink/mdw/node/.mdw/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "com.centurylink.mdw.node",
-  "schemaVersion": "6.0",
-  "version": "6.0.13"
-}

--- a/mdw-workflow/assets/com/centurylink/mdw/node/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/node/.mdw/package.yaml
@@ -1,3 +1,3 @@
 schemaVersion: '6.1'
 name: com.centurylink.mdw.node
-version: 6.0.13
+version: 6.1.01

--- a/mdw-workflow/assets/com/centurylink/mdw/node/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/node/.mdw/package.yaml
@@ -1,0 +1,3 @@
+schemaVersion: '6.0'
+name: com.centurylink.mdw.node
+version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/node/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/node/.mdw/package.yaml
@@ -1,3 +1,3 @@
-schemaVersion: '6.0'
+schemaVersion: '6.1'
 name: com.centurylink.mdw.node
 version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/react/.mdw/package.json
+++ b/mdw-workflow/assets/com/centurylink/mdw/react/.mdw/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "com.centurylink.mdw.react",
-  "schemaVersion": "6.0",
-  "version": "6.0.13"
-}

--- a/mdw-workflow/assets/com/centurylink/mdw/react/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/react/.mdw/package.yaml
@@ -1,3 +1,3 @@
-schemaVersion: '6.0'
+schemaVersion: '6.1'
 name: com.centurylink.mdw.react
 version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/react/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/react/.mdw/package.yaml
@@ -1,3 +1,3 @@
 schemaVersion: '6.1'
 name: com.centurylink.mdw.react
-version: 6.0.13
+version: 6.1.01

--- a/mdw-workflow/assets/com/centurylink/mdw/react/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/react/.mdw/package.yaml
@@ -1,0 +1,3 @@
+schemaVersion: '6.0'
+name: com.centurylink.mdw.react
+version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/routing/.mdw/package.json
+++ b/mdw-workflow/assets/com/centurylink/mdw/routing/.mdw/package.json
@@ -1,6 +1,0 @@
-{
-  "attributes": {"ExclusionRoutingList": "AppSummary,SystemInfo,AuthenticatedUser,Packages,Assets,GitVcs,Users,System"},
-  "name": "com.centurylink.mdw.routing",
-  "schemaVersion": "6.0",
-  "version": "6.0.13"
-}

--- a/mdw-workflow/assets/com/centurylink/mdw/routing/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/routing/.mdw/package.yaml
@@ -1,4 +1,4 @@
-schemaVersion: '6.0'
+schemaVersion: '6.1'
 name: com.centurylink.mdw.routing
 attributes:
   ExclusionRoutingList: AppSummary,SystemInfo,AuthenticatedUser,Packages,Assets,GitVcs,Users,System

--- a/mdw-workflow/assets/com/centurylink/mdw/routing/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/routing/.mdw/package.yaml
@@ -1,0 +1,5 @@
+schemaVersion: '6.0'
+name: com.centurylink.mdw.routing
+attributes:
+  ExclusionRoutingList: AppSummary,SystemInfo,AuthenticatedUser,Packages,Assets,GitVcs,Users,System
+version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/routing/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/routing/.mdw/package.yaml
@@ -2,4 +2,4 @@ schemaVersion: '6.1'
 name: com.centurylink.mdw.routing
 attributes:
   ExclusionRoutingList: AppSummary,SystemInfo,AuthenticatedUser,Packages,Assets,GitVcs,Users,System
-version: 6.0.13
+version: 6.1.01

--- a/mdw-workflow/assets/com/centurylink/mdw/sendgrid/.mdw/package.json
+++ b/mdw-workflow/assets/com/centurylink/mdw/sendgrid/.mdw/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "com.centurylink.mdw.sendgrid",
-  "schemaVersion": "6.0",
-  "version": "6.0.13"
-}

--- a/mdw-workflow/assets/com/centurylink/mdw/sendgrid/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/sendgrid/.mdw/package.yaml
@@ -1,0 +1,3 @@
+schemaVersion: '6.0'
+name: com.centurylink.mdw.sendgrid
+version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/sendgrid/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/sendgrid/.mdw/package.yaml
@@ -1,3 +1,3 @@
 schemaVersion: '6.1'
 name: com.centurylink.mdw.sendgrid
-version: 6.0.13
+version: 6.1.01

--- a/mdw-workflow/assets/com/centurylink/mdw/sendgrid/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/sendgrid/.mdw/package.yaml
@@ -1,3 +1,3 @@
-schemaVersion: '6.0'
+schemaVersion: '6.1'
 name: com.centurylink.mdw.sendgrid
 version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/services/api/samples/.mdw/package.json
+++ b/mdw-workflow/assets/com/centurylink/mdw/services/api/samples/.mdw/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "com.centurylink.mdw.services.api.samples",
-  "schemaVersion": "6.0",
-  "version": "6.0.13"
-}

--- a/mdw-workflow/assets/com/centurylink/mdw/services/api/samples/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/services/api/samples/.mdw/package.yaml
@@ -1,3 +1,3 @@
 schemaVersion: '6.1'
 name: com.centurylink.mdw.services.api.samples
-version: 6.0.13
+version: 6.1.01

--- a/mdw-workflow/assets/com/centurylink/mdw/services/api/samples/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/services/api/samples/.mdw/package.yaml
@@ -1,3 +1,3 @@
-schemaVersion: '6.0'
+schemaVersion: '6.1'
 name: com.centurylink.mdw.services.api.samples
 version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/services/api/samples/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/services/api/samples/.mdw/package.yaml
@@ -1,0 +1,3 @@
+schemaVersion: '6.0'
+name: com.centurylink.mdw.services.api.samples
+version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/slack/.mdw/package.json
+++ b/mdw-workflow/assets/com/centurylink/mdw/slack/.mdw/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "com.centurylink.mdw.slack",
-  "schemaVersion": "6.0",
-  "version": "6.0.13"
-}

--- a/mdw-workflow/assets/com/centurylink/mdw/slack/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/slack/.mdw/package.yaml
@@ -1,3 +1,3 @@
-schemaVersion: '6.0'
+schemaVersion: '6.1'
 name: com.centurylink.mdw.slack
 version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/slack/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/slack/.mdw/package.yaml
@@ -1,3 +1,3 @@
 schemaVersion: '6.1'
 name: com.centurylink.mdw.slack
-version: 6.0.13
+version: 6.1.01

--- a/mdw-workflow/assets/com/centurylink/mdw/slack/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/slack/.mdw/package.yaml
@@ -1,0 +1,3 @@
+schemaVersion: '6.0'
+name: com.centurylink.mdw.slack
+version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/system/filepanel/.mdw/package.json
+++ b/mdw-workflow/assets/com/centurylink/mdw/system/filepanel/.mdw/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "com.centurylink.mdw.system.filepanel",
-  "schemaVersion": "6.0",
-  "version": "6.0.13"
-}

--- a/mdw-workflow/assets/com/centurylink/mdw/system/filepanel/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/system/filepanel/.mdw/package.yaml
@@ -1,3 +1,3 @@
 schemaVersion: '6.1'
 name: com.centurylink.mdw.system.filepanel
-version: 6.0.13
+version: 6.1.01

--- a/mdw-workflow/assets/com/centurylink/mdw/system/filepanel/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/system/filepanel/.mdw/package.yaml
@@ -1,3 +1,3 @@
-schemaVersion: '6.0'
+schemaVersion: '6.1'
 name: com.centurylink.mdw.system.filepanel
 version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/system/filepanel/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/system/filepanel/.mdw/package.yaml
@@ -1,0 +1,3 @@
+schemaVersion: '6.0'
+name: com.centurylink.mdw.system.filepanel
+version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/task/.mdw/package.json
+++ b/mdw-workflow/assets/com/centurylink/mdw/task/.mdw/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "com.centurylink.mdw.task",
-  "schemaVersion": "6.0",
-  "version": "6.0.13"
-}

--- a/mdw-workflow/assets/com/centurylink/mdw/task/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/task/.mdw/package.yaml
@@ -1,3 +1,3 @@
-schemaVersion: '6.0'
+schemaVersion: '6.1'
 name: com.centurylink.mdw.task
 version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/task/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/task/.mdw/package.yaml
@@ -1,3 +1,3 @@
 schemaVersion: '6.1'
 name: com.centurylink.mdw.task
-version: 6.0.13
+version: 6.1.01

--- a/mdw-workflow/assets/com/centurylink/mdw/task/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/task/.mdw/package.yaml
@@ -1,0 +1,3 @@
+schemaVersion: '6.0'
+name: com.centurylink.mdw.task
+version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/testing/.mdw/package.json
+++ b/mdw-workflow/assets/com/centurylink/mdw/testing/.mdw/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "com.centurylink.mdw.testing",
-  "schemaVersion": "6.0",
-  "version": "6.0.13"
-}

--- a/mdw-workflow/assets/com/centurylink/mdw/testing/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/testing/.mdw/package.yaml
@@ -1,3 +1,3 @@
 schemaVersion: '6.1'
 name: com.centurylink.mdw.testing
-version: 6.0.13
+version: 6.1.01

--- a/mdw-workflow/assets/com/centurylink/mdw/testing/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/testing/.mdw/package.yaml
@@ -1,0 +1,3 @@
+schemaVersion: '6.0'
+name: com.centurylink.mdw.testing
+version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/testing/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/testing/.mdw/package.yaml
@@ -1,3 +1,3 @@
-schemaVersion: '6.0'
+schemaVersion: '6.1'
 name: com.centurylink.mdw.testing
 version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/cloud/.mdw/package.json
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/cloud/.mdw/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "com.centurylink.mdw.tests.cloud",
-  "schemaVersion": "6.0",
-  "version": "6.0.13"
-}

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/cloud/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/cloud/.mdw/package.yaml
@@ -1,0 +1,3 @@
+schemaVersion: '6.0'
+name: com.centurylink.mdw.tests.cloud
+version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/cloud/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/cloud/.mdw/package.yaml
@@ -1,3 +1,3 @@
-schemaVersion: '6.0'
+schemaVersion: '6.1'
 name: com.centurylink.mdw.tests.cloud
 version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/cloud/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/cloud/.mdw/package.yaml
@@ -1,3 +1,3 @@
 schemaVersion: '6.1'
 name: com.centurylink.mdw.tests.cloud
-version: 6.0.13
+version: 6.1.01

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/multiver/.mdw/package.json
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/multiver/.mdw/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "com.centurylink.mdw.tests.multiver",
-  "schemaVersion": "6.0",
-  "version": "6.0.13"
-}

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/multiver/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/multiver/.mdw/package.yaml
@@ -1,3 +1,3 @@
 schemaVersion: '6.1'
 name: com.centurylink.mdw.tests.multiver
-version: 6.0.13
+version: 6.1.01

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/multiver/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/multiver/.mdw/package.yaml
@@ -1,0 +1,3 @@
+schemaVersion: '6.0'
+name: com.centurylink.mdw.tests.multiver
+version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/multiver/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/multiver/.mdw/package.yaml
@@ -1,3 +1,3 @@
-schemaVersion: '6.0'
+schemaVersion: '6.1'
 name: com.centurylink.mdw.tests.multiver
 version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/routing/.mdw/package.json
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/routing/.mdw/package.json
@@ -1,6 +1,0 @@
-{
-  "attributes": {"mdw.task.resume.notify.endpoint": {"mdw.task.resume.notify.endpoint": "http://mdwapp:ldap_012@localhost:8989/mdw"}},
-  "name": "com.centurylink.mdw.tests.routing",
-  "schemaVersion": "6.0",
-  "version": "6.0.13"
-}

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/routing/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/routing/.mdw/package.yaml
@@ -1,0 +1,5 @@
+schemaVersion: '6.0'
+name: com.centurylink.mdw.tests.routing
+attributes:
+  mdw.task.resume.notify.endpoint: http://mdwapp:ldap_012@localhost:8989/mdw
+version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/routing/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/routing/.mdw/package.yaml
@@ -1,4 +1,4 @@
-schemaVersion: '6.0'
+schemaVersion: '6.1'
 name: com.centurylink.mdw.tests.routing
 attributes:
   mdw.task.resume.notify.endpoint: http://mdwapp:ldap_012@localhost:8989/mdw

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/routing/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/routing/.mdw/package.yaml
@@ -2,4 +2,4 @@ schemaVersion: '6.1'
 name: com.centurylink.mdw.tests.routing
 attributes:
   mdw.task.resume.notify.endpoint: http://mdwapp:ldap_012@localhost:8989/mdw
-version: 6.0.13
+version: 6.1.01

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/server/.mdw/package.json
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/server/.mdw/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "com.centurylink.mdw.tests.server",
-  "schemaVersion": "6.0",
-  "version": "6.0.13"
-}

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/server/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/server/.mdw/package.yaml
@@ -1,0 +1,3 @@
+schemaVersion: '6.0'
+name: com.centurylink.mdw.tests.server
+version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/server/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/server/.mdw/package.yaml
@@ -1,3 +1,3 @@
-schemaVersion: '6.0'
+schemaVersion: '6.1'
 name: com.centurylink.mdw.tests.server
 version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/server/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/server/.mdw/package.yaml
@@ -1,3 +1,3 @@
 schemaVersion: '6.1'
 name: com.centurylink.mdw.tests.server
-version: 6.0.13
+version: 6.1.01

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/services/.mdw/package.json
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/services/.mdw/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "com.centurylink.mdw.tests.services",
-  "schemaVersion": "6.0",
-  "version": "6.0.13"
-}

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/services/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/services/.mdw/package.yaml
@@ -1,0 +1,3 @@
+schemaVersion: '6.0'
+name: com.centurylink.mdw.tests.services
+version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/services/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/services/.mdw/package.yaml
@@ -1,3 +1,3 @@
-schemaVersion: '6.0'
+schemaVersion: '6.1'
 name: com.centurylink.mdw.tests.services
 version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/services/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/services/.mdw/package.yaml
@@ -1,3 +1,3 @@
 schemaVersion: '6.1'
 name: com.centurylink.mdw.tests.services
-version: 6.0.13
+version: 6.1.01

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/stubbing/.mdw/package.json
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/stubbing/.mdw/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "com.centurylink.mdw.tests.stubbing",
-  "schemaVersion": "6.0",
-  "version": "6.0.13"
-}

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/stubbing/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/stubbing/.mdw/package.yaml
@@ -1,3 +1,3 @@
-schemaVersion: '6.0'
+schemaVersion: '6.1'
 name: com.centurylink.mdw.tests.stubbing
 version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/stubbing/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/stubbing/.mdw/package.yaml
@@ -1,3 +1,3 @@
 schemaVersion: '6.1'
 name: com.centurylink.mdw.tests.stubbing
-version: 6.0.13
+version: 6.1.01

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/stubbing/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/stubbing/.mdw/package.yaml
@@ -1,0 +1,3 @@
+schemaVersion: '6.0'
+name: com.centurylink.mdw.tests.stubbing
+version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/tasks/.mdw/package.json
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/tasks/.mdw/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "com.centurylink.mdw.tests.tasks",
-  "schemaVersion": "6.0",
-  "version": "6.0.13"
-}

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/tasks/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/tasks/.mdw/package.yaml
@@ -1,3 +1,3 @@
-schemaVersion: '6.0'
+schemaVersion: '6.1'
 name: com.centurylink.mdw.tests.tasks
 version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/tasks/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/tasks/.mdw/package.yaml
@@ -1,0 +1,3 @@
+schemaVersion: '6.0'
+name: com.centurylink.mdw.tests.tasks
+version: 6.0.13

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/tasks/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/tasks/.mdw/package.yaml
@@ -1,3 +1,3 @@
 schemaVersion: '6.1'
 name: com.centurylink.mdw.tests.tasks
-version: 6.0.13
+version: 6.1.01

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/workflow/.mdw/package.json
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/workflow/.mdw/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "com.centurylink.mdw.tests.workflow",
-  "schemaVersion": "6.0",
-  "version": "6.0.13"
-}

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/workflow/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/workflow/.mdw/package.yaml
@@ -1,4 +1,4 @@
 workgroup: Common
-schemaVersion: '6.0'
+schemaVersion: '6.1'
 name: com.centurylink.mdw.tests.workflow
 version: 6.0.14

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/workflow/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/workflow/.mdw/package.yaml
@@ -1,0 +1,4 @@
+workgroup: Common
+schemaVersion: '6.0'
+name: com.centurylink.mdw.tests.workflow
+version: 6.0.14

--- a/mdw-workflow/assets/com/centurylink/mdw/tests/workflow/.mdw/package.yaml
+++ b/mdw-workflow/assets/com/centurylink/mdw/tests/workflow/.mdw/package.yaml
@@ -1,4 +1,4 @@
 workgroup: Common
 schemaVersion: '6.1'
 name: com.centurylink.mdw.tests.workflow
-version: 6.0.14
+version: 6.1.01


### PR DESCRIPTION
The package.json for com.centurylink.mdw.tests.routing is having the grouped attributes like below
"attributes": {"mdw.task.resume.notify.endpoint": {"mdw.task.resume.notify.endpoint": "http://mdwapp:ldap_012@localhost:8989/mdw"}},

Since mdw6 does not support grouped attributes , I changed it as non grouped attribute in package.yaml
attributes:
  mdw.task.resume.notify.endpoint: http://mdwapp:ldap_012@localhost:8989/mdw